### PR TITLE
Sqlite db tracking

### DIFF
--- a/patchseq_autotrace/commands/cleanup_fail.py
+++ b/patchseq_autotrace/commands/cleanup_fail.py
@@ -1,10 +1,15 @@
 import os
 import shutil
 import argschema as ags
+from patchseq_autotrace.database_tools import status_update
 
 
 class IO_Schema(ags.ArgSchema):
     specimen_dir = ags.fields.InputDir(description='Input Subject Directory')
+    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file")
+    autotrace_tracking_database = ags.fields.InputFile(
+        description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
+                    "patchseq_autotrace.database_tools prior to running this script")
 
 
 def main(args, **kwargs):
@@ -20,6 +25,14 @@ def main(args, **kwargs):
         if os.path.exists(full_dir_name):
             print(full_dir_name)
             shutil.rmtree(full_dir_name)
+
+    sqlite_runs_table_id = args['sqlite_runs_table_id']
+    autotrace_tracking_database = args['autotrace_tracking_database']
+
+    status_update(database_path=autotrace_tracking_database,
+                  runs_unique_id=sqlite_runs_table_id,
+                  process_name='pipeline',
+                  state='finish')
 
 def console_script():
     module = ags.ArgSchemaParser(schema_type=IO_Schema)

--- a/patchseq_autotrace/commands/post_process_segmentation.py
+++ b/patchseq_autotrace/commands/post_process_segmentation.py
@@ -1,19 +1,36 @@
 import os
 import argschema as ags
 from patchseq_autotrace.processes.postprocess import postprocess
+from patchseq_autotrace.database_tools import status_update
 
 
 class IO_Schema(ags.ArgSchema):
     specimen_dir = ags.fields.InputDir(description='Input Subject Directory')
     model_name = ags.fields.Str(description='model name to use ')
-
+    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file")
+    autotrace_tracking_database = ags.fields.InputFile(
+        description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
+                    "patchseq_autotrace.database_tools prior to running this script")
 
 def main(args, **kwargs):
 
     specimen_dir = args['specimen_dir']
     model_name = args['model_name']
+    sqlite_runs_table_id = args['sqlite_runs_table_id']
+    autotrace_tracking_database = args['autotrace_tracking_database']
+
+    status_update(database_path=autotrace_tracking_database,
+                  runs_unique_id=sqlite_runs_table_id,
+                  process_name='postprocessing',
+                  state='start')
+
     segmentation_dir = os.path.join(specimen_dir, "Segmentation")
     postprocess(specimen_dir, segmentation_dir=segmentation_dir, model_name=model_name)
+
+    status_update(database_path=autotrace_tracking_database,
+                  runs_unique_id=sqlite_runs_table_id,
+                  process_name='postprocessing',
+                  state='finish')
 
 
 def console_script():

--- a/patchseq_autotrace/commands/run_database_sweep.py
+++ b/patchseq_autotrace/commands/run_database_sweep.py
@@ -2,7 +2,6 @@ import sqlite3
 import time
 import os
 import argschema as ags
-from patchseq_autotrace.database_tools import create_runs_table
 
 # This script is meant to sweep through an autotrace output directory and post-hoc update a sqlite .db file
 class IO_Schema(ags.ArgSchema):
@@ -15,82 +14,86 @@ def main(args, **kwargs):
     database_file = args['database_file']
     autotrace_root_directory = args['autotrace_root_directory']
 
-    create_runs_table(database_file)
-    # TODO: Fill in updated DB fields post-hoc from job files
+    con = sqlite3.connect(database_file)
+    cur = con.cursor()
 
-    # con = sqlite3.connect(database_file)
-    # cur = con.cursor()
-    #
-    # # check that the specimen records table exists
-    # res = cur.execute("SELECT name FROM sqlite_master")
-    # if ("specimen_records",) not in res.fetchall():
-    #     cur.execute(
-    #         "CREATE TABLE specimen_records(specimen_id, has_raw_autotrace, autotrace_version, file_generated_timestamp)")
-    #
-    # res = cur.execute("SELECT * FROM specimen_records")
-    # existing_specimen_records = res.fetchall()
-    # package_list = []
-    # for spid in os.listdir(autotrace_root_directory):
-    #     try:
-    #         int(spid)
-    #     except:
-    #         # This is not a valid specimen ID if it is not an integer
-    #         continue
+    # check that the specimen records table exists
+    res = cur.execute("SELECT name FROM sqlite_master")
+    if ("basic_post_hoc_specimen_records",) not in res.fetchall():
+        cur.execute(
+            "CREATE TABLE basic_post_hoc_specimen_records(specimen_id, has_raw_autotrace, autotrace_version, file_generated_timestamp)")
 
-    #
-    #     specimen_dir = os.path.join(autotrace_root_directory, spid)
-    #     raw_swc_dir = os.path.join(specimen_dir, "SWC", "Raw")
-    #
-    #     swc_files = []
-    #     if os.path.exists(raw_swc_dir):
-    #         swc_files = [f for f in os.listdir(raw_swc_dir) if f.endswith(".swc")]
-    #
-    #     has_raw_swc = 0
-    #     if swc_files:
-    #         has_raw_swc = 1
-    #         for fn in swc_files:
-    #             # versioning of the patchseq_autotrace codebase
-    #             # was incorporated into the file name so what was
-    #             # previously saved as:
-    #             # 1078838829_Aspiny1.0_1.0.swc
-    #             # is now saved as:
-    #             # 1078838829_Aspiny1.0_0.1.2_1.0.swc
-    #             # where the _0.1.2_ represents the version of
-    #             # patchseq_autotrace used to generate the file
-    #             swc_pth = os.path.join(raw_swc_dir, fn)
-    #
-    #             created_time = os.path.getctime(swc_pth)
-    #             created_time = time.ctime(created_time)
-    #
-    #             file_name_pieces = fn.split("_")
-    #             if len(file_name_pieces) != 4:
-    #                 version = "0"
-    #             else:
-    #                 version = file_name_pieces[2]
-    #
-    #             package = (int(spid), has_raw_swc, version, created_time)
-    #
-    #             if package not in existing_specimen_records:
-    #                 package_list.append(package)
-    #
-    #     else:
-    #         version = "None"
-    #         created_time = "None"
-    #         package = (int(spid), has_raw_swc, version, created_time)
-    #         if package not in existing_specimen_records:
-    #             package_list.append(package)
-    #
-    # if package_list:
-    #     insert_string = " \n".join([f"({p[0]}, {p[1]}, '{p[2]}', '{p[3]}')," for p in package_list])[:-1]  # last comma
-    #     insert_cmd = f"""
-    #         INSERT INTO specimen_records VALUES
-    #         {insert_string}
-    #     """
-    #     cur.execute(insert_cmd)
-    #     con.commit()
-    #
-    # cur.close()
-    # con.close()
+    res = cur.execute("SELECT * FROM basic_post_hoc_specimen_records")
+    existing_specimen_records = res.fetchall()
+    package_list = []
+
+    cur.close()
+    con.close()
+
+    for spid in os.listdir(autotrace_root_directory):
+        try:
+            int(spid)
+        except:
+            # This is not a valid specimen ID if it is not an integer
+            continue
+
+
+        specimen_dir = os.path.join(autotrace_root_directory, spid)
+        raw_swc_dir = os.path.join(specimen_dir, "SWC", "Raw")
+
+        swc_files = []
+        if os.path.exists(raw_swc_dir):
+            swc_files = [f for f in os.listdir(raw_swc_dir) if f.endswith(".swc")]
+
+        has_raw_swc = 0
+        if swc_files:
+            has_raw_swc = 1
+            for fn in swc_files:
+                # versioning of the patchseq_autotrace codebase
+                # was incorporated into the file name so what was
+                # previously saved as:
+                # 1078838829_Aspiny1.0_1.0.swc
+                # is now saved as:
+                # 1078838829_Aspiny1.0_0.1.2_1.0.swc
+                # where the _0.1.2_ represents the version of
+                # patchseq_autotrace used to generate the file
+                swc_pth = os.path.join(raw_swc_dir, fn)
+
+                created_time = os.path.getctime(swc_pth)
+                created_time = time.ctime(created_time)
+
+                file_name_pieces = fn.split("_")
+                if len(file_name_pieces) != 4:
+                    version = "0"
+                else:
+                    version = file_name_pieces[2]
+
+                package = (int(spid), has_raw_swc, version, created_time)
+
+                if package not in existing_specimen_records:
+                    package_list.append(package)
+
+        else:
+            version = "None"
+            created_time = "None"
+            package = (int(spid), has_raw_swc, version, created_time)
+            if package not in existing_specimen_records:
+                package_list.append(package)
+
+    if package_list:
+        con = sqlite3.connect(database_file)
+        cur = con.cursor()
+
+        insert_string = " \n".join([f"({p[0]}, {p[1]}, '{p[2]}', '{p[3]}')," for p in package_list])[:-1]  # last comma
+        insert_cmd = f"""
+            INSERT INTO basic_post_hoc_specimen_records VALUES
+            {insert_string}
+        """
+        cur.execute(insert_cmd)
+        con.commit()
+
+    cur.close()
+    con.close()
 
 
 def console_script():

--- a/patchseq_autotrace/commands/run_database_sweep.py
+++ b/patchseq_autotrace/commands/run_database_sweep.py
@@ -1,0 +1,106 @@
+import sqlite3
+import time
+import os
+import argschema as ags
+
+
+# This script is meant to sweep through an autotrace output directory and update a sqlite .db file with the following
+# data:
+# 1. Specimen ID - integer identifier for each specimen
+# 2. has_raw_autotrace - boolean to tell if the raw autotrace file was generated
+# 3. autotrace_version - which version of patchseq_autotrace codebase was used to generate the raw autotrace file
+# 4. file_generated_timestamp - the datetime at which the file was generated
+
+class IO_Schema(ags.ArgSchema):
+    database_file = ags.fields.OutputFile(description='.db file')
+    autotrace_root_directory = ags.fields.InputDir(default="/allen/programs/celltypes/workgroups/mousecelltypes"
+                                                           "/AutotraceReconstruction")
+
+
+def main(args, **kwargs):
+    database_file = args['database_file']
+    autotrace_root_directory = args['autotrace_root_directory']
+
+    if not os.path.exists(database_file):
+        con = sqlite3.connect(database_file)
+        cur = con.cursor()
+        cur.execute(
+            "CREATE TABLE specimen_records(specimen_id, has_raw_autotrace, autotrace_version, file_generated_timestamp)")
+        con.close()
+        cur.close()
+
+    con = sqlite3.connect(database_file)
+    cur = con.cursor()
+    res = cur.execute("SELECT * FROM specimen_records")
+    existing_specimen_records = res.fetchall()
+    package_list = []
+    for spid in os.listdir(autotrace_root_directory):
+        try:
+            int(spid)
+        except:
+            # This is not a valid specimen ID if it is not an integer
+            continue
+
+        specimen_dir = os.path.join(autotrace_root_directory, spid)
+        raw_swc_dir = os.path.join(specimen_dir, "SWC", "Raw")
+
+        swc_files = []
+        if os.path.exists(raw_swc_dir):
+            swc_files = [f for f in os.listdir(raw_swc_dir) if f.endswith(".swc")]
+
+        has_raw_swc = 0
+        if swc_files:
+            has_raw_swc = 1
+            for fn in swc_files:
+                # versioning of the patchseq_autotrace codebase
+                # was incorporated into the file name so what was
+                # previously saved as:
+                # 1078838829_Aspiny1.0_1.0.swc
+                # is now saved as:
+                # 1078838829_Aspiny1.0_0.1.2_1.0.swc
+                # where the _0.1.2_ represents the version of
+                # patchseq_autotrace used to generate the file
+                swc_pth = os.path.join(raw_swc_dir, fn)
+
+                created_time = os.path.getctime(swc_pth)
+                created_time = time.ctime(created_time)
+
+                file_name_pieces = fn.split("_")
+                if len(file_name_pieces) != 4:
+                    version = "0"
+                else:
+                    version = file_name_pieces[2]
+
+                package = (int(spid), has_raw_swc, version, created_time)
+
+                if package not in existing_specimen_records:
+                    package_list.append(package)
+
+        else:
+            version = "None"
+            created_time = "None"
+            package = (int(spid), has_raw_swc, version, created_time)
+            if package not in existing_specimen_records:
+                package_list.append(package)
+
+    if package_list:
+        insert_string = " \n".join([f"({p[0]}, {p[1]}, '{p[2]}', '{p[3]}')," for p in package_list])[:-1]  # last comma
+        insert_cmd = f"""
+            INSERT INTO specimen_records VALUES
+            {insert_string}
+        """
+        cur.execute(insert_cmd)
+        con.commit()
+
+    cur.close()
+    con.close()
+
+
+def console_script():
+    module = ags.ArgSchemaParser(schema_type=IO_Schema)
+    main(module.args)
+
+
+if __name__ == "__main__":
+    module = ags.ArgSchemaParser(schema_type=IO_Schema)
+    main(module.args)

--- a/patchseq_autotrace/commands/run_database_sweep.py
+++ b/patchseq_autotrace/commands/run_database_sweep.py
@@ -31,6 +31,13 @@ def main(args, **kwargs):
 
     con = sqlite3.connect(database_file)
     cur = con.cursor()
+
+    # check that the specimen records table exists
+    res = cur.execute("SELECT name FROM sqlite_master")
+    if ("specimen_records",) not in res.fetchall():
+        cur.execute(
+            "CREATE TABLE specimen_records(specimen_id, has_raw_autotrace, autotrace_version, file_generated_timestamp)")
+
     res = cur.execute("SELECT * FROM specimen_records")
     existing_specimen_records = res.fetchall()
     package_list = []

--- a/patchseq_autotrace/commands/run_database_sweep.py
+++ b/patchseq_autotrace/commands/run_database_sweep.py
@@ -2,15 +2,9 @@ import sqlite3
 import time
 import os
 import argschema as ags
+from patchseq_autotrace.database_tools import create_runs_table
 
-
-# This script is meant to sweep through an autotrace output directory and update a sqlite .db file with the following
-# data:
-# 1. Specimen ID - integer identifier for each specimen
-# 2. has_raw_autotrace - boolean to tell if the raw autotrace file was generated
-# 3. autotrace_version - which version of patchseq_autotrace codebase was used to generate the raw autotrace file
-# 4. file_generated_timestamp - the datetime at which the file was generated
-
+# This script is meant to sweep through an autotrace output directory and post-hoc update a sqlite .db file
 class IO_Schema(ags.ArgSchema):
     database_file = ags.fields.OutputFile(description='.db file')
     autotrace_root_directory = ags.fields.InputDir(default="/allen/programs/celltypes/workgroups/mousecelltypes"
@@ -21,86 +15,82 @@ def main(args, **kwargs):
     database_file = args['database_file']
     autotrace_root_directory = args['autotrace_root_directory']
 
-    if not os.path.exists(database_file):
-        con = sqlite3.connect(database_file)
-        cur = con.cursor()
-        cur.execute(
-            "CREATE TABLE specimen_records(specimen_id, has_raw_autotrace, autotrace_version, file_generated_timestamp)")
-        con.close()
-        cur.close()
+    create_runs_table(database_file)
+    # TODO: Fill in updated DB fields post-hoc from job files
 
-    con = sqlite3.connect(database_file)
-    cur = con.cursor()
+    # con = sqlite3.connect(database_file)
+    # cur = con.cursor()
+    #
+    # # check that the specimen records table exists
+    # res = cur.execute("SELECT name FROM sqlite_master")
+    # if ("specimen_records",) not in res.fetchall():
+    #     cur.execute(
+    #         "CREATE TABLE specimen_records(specimen_id, has_raw_autotrace, autotrace_version, file_generated_timestamp)")
+    #
+    # res = cur.execute("SELECT * FROM specimen_records")
+    # existing_specimen_records = res.fetchall()
+    # package_list = []
+    # for spid in os.listdir(autotrace_root_directory):
+    #     try:
+    #         int(spid)
+    #     except:
+    #         # This is not a valid specimen ID if it is not an integer
+    #         continue
 
-    # check that the specimen records table exists
-    res = cur.execute("SELECT name FROM sqlite_master")
-    if ("specimen_records",) not in res.fetchall():
-        cur.execute(
-            "CREATE TABLE specimen_records(specimen_id, has_raw_autotrace, autotrace_version, file_generated_timestamp)")
-
-    res = cur.execute("SELECT * FROM specimen_records")
-    existing_specimen_records = res.fetchall()
-    package_list = []
-    for spid in os.listdir(autotrace_root_directory):
-        try:
-            int(spid)
-        except:
-            # This is not a valid specimen ID if it is not an integer
-            continue
-
-        specimen_dir = os.path.join(autotrace_root_directory, spid)
-        raw_swc_dir = os.path.join(specimen_dir, "SWC", "Raw")
-
-        swc_files = []
-        if os.path.exists(raw_swc_dir):
-            swc_files = [f for f in os.listdir(raw_swc_dir) if f.endswith(".swc")]
-
-        has_raw_swc = 0
-        if swc_files:
-            has_raw_swc = 1
-            for fn in swc_files:
-                # versioning of the patchseq_autotrace codebase
-                # was incorporated into the file name so what was
-                # previously saved as:
-                # 1078838829_Aspiny1.0_1.0.swc
-                # is now saved as:
-                # 1078838829_Aspiny1.0_0.1.2_1.0.swc
-                # where the _0.1.2_ represents the version of
-                # patchseq_autotrace used to generate the file
-                swc_pth = os.path.join(raw_swc_dir, fn)
-
-                created_time = os.path.getctime(swc_pth)
-                created_time = time.ctime(created_time)
-
-                file_name_pieces = fn.split("_")
-                if len(file_name_pieces) != 4:
-                    version = "0"
-                else:
-                    version = file_name_pieces[2]
-
-                package = (int(spid), has_raw_swc, version, created_time)
-
-                if package not in existing_specimen_records:
-                    package_list.append(package)
-
-        else:
-            version = "None"
-            created_time = "None"
-            package = (int(spid), has_raw_swc, version, created_time)
-            if package not in existing_specimen_records:
-                package_list.append(package)
-
-    if package_list:
-        insert_string = " \n".join([f"({p[0]}, {p[1]}, '{p[2]}', '{p[3]}')," for p in package_list])[:-1]  # last comma
-        insert_cmd = f"""
-            INSERT INTO specimen_records VALUES
-            {insert_string}
-        """
-        cur.execute(insert_cmd)
-        con.commit()
-
-    cur.close()
-    con.close()
+    #
+    #     specimen_dir = os.path.join(autotrace_root_directory, spid)
+    #     raw_swc_dir = os.path.join(specimen_dir, "SWC", "Raw")
+    #
+    #     swc_files = []
+    #     if os.path.exists(raw_swc_dir):
+    #         swc_files = [f for f in os.listdir(raw_swc_dir) if f.endswith(".swc")]
+    #
+    #     has_raw_swc = 0
+    #     if swc_files:
+    #         has_raw_swc = 1
+    #         for fn in swc_files:
+    #             # versioning of the patchseq_autotrace codebase
+    #             # was incorporated into the file name so what was
+    #             # previously saved as:
+    #             # 1078838829_Aspiny1.0_1.0.swc
+    #             # is now saved as:
+    #             # 1078838829_Aspiny1.0_0.1.2_1.0.swc
+    #             # where the _0.1.2_ represents the version of
+    #             # patchseq_autotrace used to generate the file
+    #             swc_pth = os.path.join(raw_swc_dir, fn)
+    #
+    #             created_time = os.path.getctime(swc_pth)
+    #             created_time = time.ctime(created_time)
+    #
+    #             file_name_pieces = fn.split("_")
+    #             if len(file_name_pieces) != 4:
+    #                 version = "0"
+    #             else:
+    #                 version = file_name_pieces[2]
+    #
+    #             package = (int(spid), has_raw_swc, version, created_time)
+    #
+    #             if package not in existing_specimen_records:
+    #                 package_list.append(package)
+    #
+    #     else:
+    #         version = "None"
+    #         created_time = "None"
+    #         package = (int(spid), has_raw_swc, version, created_time)
+    #         if package not in existing_specimen_records:
+    #             package_list.append(package)
+    #
+    # if package_list:
+    #     insert_string = " \n".join([f"({p[0]}, {p[1]}, '{p[2]}', '{p[3]}')," for p in package_list])[:-1]  # last comma
+    #     insert_cmd = f"""
+    #         INSERT INTO specimen_records VALUES
+    #         {insert_string}
+    #     """
+    #     cur.execute(insert_cmd)
+    #     con.commit()
+    #
+    # cur.close()
+    # con.close()
 
 
 def console_script():

--- a/patchseq_autotrace/commands/skeleton_stack_to_swc.py
+++ b/patchseq_autotrace/commands/skeleton_stack_to_swc.py
@@ -1,18 +1,34 @@
 import argschema as ags
 from patchseq_autotrace.processes.stack_to_swc import skeleton_to_swc
+from patchseq_autotrace.database_tools import status_update
 
 
 class IO_Schema(ags.ArgSchema):
     specimen_dir = ags.fields.InputDir(description='Input Subject Directory')
     model_name = ags.fields.Str(description='model name to use ')
+    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file")
+    autotrace_tracking_database = ags.fields.InputFile(
+        description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
+                    "patchseq_autotrace.database_tools prior to running this script")
 
 
 def main(args, **kwargs):
     specimen_dir = args['specimen_dir']
     model_name = args['model_name']
+    sqlite_runs_table_id = args['sqlite_runs_table_id']
+    autotrace_tracking_database = args['autotrace_tracking_database']
+
+    status_update(database_path=autotrace_tracking_database,
+                  runs_unique_id=sqlite_runs_table_id,
+                  process_name='stack2swc',
+                  state='start')
 
     skeleton_to_swc(specimen_dir=specimen_dir, model_and_version=model_name)
 
+    status_update(database_path=autotrace_tracking_database,
+                  runs_unique_id=sqlite_runs_table_id,
+                  process_name='stack2swc',
+                  state='finish')
 
 def console_script():
     module = ags.ArgSchemaParser(schema_type=IO_Schema)

--- a/patchseq_autotrace/database_tools.py
+++ b/patchseq_autotrace/database_tools.py
@@ -1,0 +1,96 @@
+import sqlite3
+import datetime
+import os
+
+
+def status_update(database_path, runs_unique_id, process_name, state):
+    """
+    Update status of a row in the runs table
+
+    :param runs_unique_id: specimen_runs database unique row id
+    :param database_path: path to sqlite .db file
+    :param process_name: str, must be one of ['preprocessing', 'segmentation', 'postprocessing', 'stack2swc']
+    :param state: str, must be one of ['start', 'finish']
+    :return: None
+
+    """
+    # get the slurm job id that this process is being run on
+    if 'SLURM_JOB_ID' in os.environ.keys():
+        slurm_id = os.environ['SLURM_JOB_ID']
+    else:
+        # if it is not run on slurm just give it a dummy value of 0
+        slurm_id = 0
+    submission_time = str(datetime.datetime.now())
+    status = 1
+
+    time_column = "{}_{}_time".format(process_name, state)
+    status_column = "{}_{}".format(process_name, state)
+    slurm_id_column = "{}_slurm_job_id".format(process_name)
+
+    if status_column != "pipeline_finish":
+        insert_cmd = f"""
+        UPDATE specimen_runs
+        SET {time_column} = '{submission_time}', {status_column} = {status}, {slurm_id_column} = {slurm_id} 
+        WHERE run_id = {runs_unique_id} 
+        """
+    else:
+        # Don't need to keep track of the job-id used to verify the specimen finished running the pipeline
+        insert_cmd = f"""
+        UPDATE specimen_runs
+        SET {status_column} = {status}
+        WHERE run_id = {runs_unique_id} 
+        """
+    print("Executing SQLite Command:")
+    print(insert_cmd)
+    con = sqlite3.connect(database_path)
+    cur = con.cursor()
+    cur.execute(insert_cmd)
+    con.commit()
+    cur.close()
+    con.close()
+
+
+def create_runs_table(database_path):
+    """
+    Create the specimen_runs table if it does not exist in the .db file provided
+    :param database_path: path to sqlite .db file
+    :return: None
+    """
+
+    create_runs_command = """
+    CREATE TABLE IF NOT EXISTS specimen_runs(
+    run_id INTEGER PRIMARY KEY,
+    specimen_id INTEGER, 
+    patchseq_autotrace_version TEXT,
+    submit_datetime TEXT,
+    output_dirname TEXT DEFAULT NONE,
+    preprocessing_start INTEGER DEFAULT 0,
+    preprocessing_start_time TEXT DEFAULT NONE,
+    preprocessing_finish INTEGER DEFAULT 0,
+    preprocessing_finish_time TEXT DEFAULT NONE,
+    preprocessing_slurm_job_id INTEGER DEFAULT 0,
+    segmentation_start INTEGER DEFAULT 0,
+    segmentation_start_time TEXT DEFAULT NONE,
+    segmentation_finish INTEGER DEFAULT 0,
+    segmentation_finish_time TEXT DEFAULT NONE,
+    segmentation_slurm_job_id INTEGER DEFAULT 0,
+    postprocessing_start INTEGER DEFAULT 0,
+    postprocessing_start_time TEXT DEFAULT NONE,
+    postprocessing_finish INTEGER DEFAULT 0,
+    postprocessing_finish_time TEXT DEFAULT NONE,
+    postprocessing_slurm_job_id INTEGER DEFAULT 0,
+    stack2swc_start INTEGER DEFAULT 0,
+    stack2swc_start_time TEXT DEFAULT NONE,
+    stack2swc_finish INTEGER DEFAULT 0,
+    stack2swc_finish_time TEXT DEFAULT NONE,
+    stack2swc_slurm_job_id INTEGER DEFAULT 0,
+    pipeline_finish INTEGER DEFAULT 0
+    );
+    """
+
+    con = sqlite3.connect(database_path)
+    cur = con.cursor()
+    cur.execute(create_runs_command)
+    con.commit()
+    cur.close()
+    con.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,4 @@ console_scripts =
     auto-skeleton-to-swc = patchseq_autotrace.commands.skeleton_stack_to_swc:console_script
     auto-patchseq-pipeline-hpc = patchseq_autotrace.commands.run_pipeline_on_hpc:console_script
     auto-cleanup = patchseq_autotrace.commands.cleanup_fail:console_script
+    auto-patchseq-database-sweep = patchseq_autotrace.commands.run_database_sweep:console_script


### PR DESCRIPTION
SQLite based support for:
1. post hoc basic reports (e.g. specimen id, what version of patchseq_autotrace, raw_file_exists, date created)
2. active monitoring during run-time (e.g. when a cell is submitted to run, slurm IDs, step by step timestamp and completion status)