### PR TITLE
post-processing and easier use for external users

### DIFF
--- a/patchseq_autotrace/commands/cleanup_fail.py
+++ b/patchseq_autotrace/commands/cleanup_fail.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import argschema as ags
 from patchseq_autotrace.database_tools import status_update
+from patchseq_autotrace.slurm_tools.Slurm_DAG import Slurm_DAG
 
 
 class IO_Schema(ags.ArgSchema):
@@ -10,8 +11,11 @@ class IO_Schema(ags.ArgSchema):
     autotrace_tracking_database = ags.fields.InputFile(
         description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
                     "patchseq_autotrace.database_tools prior to running this script")
-
-
+    # the below are only if swc post processing will be run
+    post_processing_workflow = ags.fields.Str(default = None, allow_none=True, description = "if not None, will submit postprocessing job here")
+    job_dir = ags.fields.InputDir(default = "None",description= "Directory with job files for this cells run")
+    model_name = ags.fields.Str(default = "None", description = "model name and version")
+    
 def main(args, **kwargs):
 
     specimen_dir = args['specimen_dir']
@@ -33,6 +37,43 @@ def main(args, **kwargs):
                   runs_unique_id=sqlite_runs_table_id,
                   process_name='pipeline',
                   state='finish')
+    
+    # If swc post processing workflow was given as an input, submit a job from here. We dont want
+    # this job tracked in our SLURM DAG because post processing takes a while to run as seen in time request
+    job_dir = args['job_dir']
+    specimen_id = os.path.basename(args['specimen_dir'])
+    post_processing_workflow = args['post_processing_workflow']
+    model_name = args['model_name']
+    if post_processing_workflow is not None:
+        # swc post processing
+        swc_pp_job_file = os.path.join(job_dir, f"{specimen_id}_swc_post_proc.sh")
+        swc_pp_kwargs = {
+            "--job-name": f"swcPP-{specimen_id}",
+            "--mail-type": "NONE",
+            "--cpus-per-task": "4",
+            "--nodes": "1",
+            "--kill-on-invalid-dep": "yes",
+            "--mem": "40gb",
+            "--time": "85:00:00",
+            "--partition": "celltypes",
+            "--output": os.path.join(job_dir, f"{specimen_id}_swc_post_proc.log")
+        }
+        swc_pp_command = f'swc_postprocess --specimen_dir {specimen_dir} --post_processing_workflow "{post_processing_workflow}" --model_name "{model_name}"'
+        swc_pp_list = ["source ~/.bashrc", "conda activate StableNeuronMorphNew", swc_pp_command]
+
+        slurm_dag_node = {
+            "id": 1,
+            "parent_id": -1,
+            "name": "swc_post_process",
+            "slurm_kwargs": swc_pp_kwargs,
+            "slurm_commands": swc_pp_list,
+            "job_file": swc_pp_job_file
+        }
+    
+        pipeline_dag = Slurm_DAG([slurm_dag_node])
+        pipeline_dag.submit_dag_to_scheduler(parent_job_id=None,
+                                            start_condition=None)
+    
 
 def console_script():
     module = ags.ArgSchemaParser(schema_type=IO_Schema)

--- a/patchseq_autotrace/commands/cleanup_fail.py
+++ b/patchseq_autotrace/commands/cleanup_fail.py
@@ -7,10 +7,10 @@ from patchseq_autotrace.slurm_tools.Slurm_DAG import Slurm_DAG
 
 class IO_Schema(ags.ArgSchema):
     specimen_dir = ags.fields.InputDir(description='Input Subject Directory')
-    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file")
+    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file", default=None, allow_none=True)
     autotrace_tracking_database = ags.fields.InputFile(
         description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
-                    "patchseq_autotrace.database_tools prior to running this script")
+                    "patchseq_autotrace.database_tools prior to running this script", default=None, allow_none=True)
     # the below are only if swc post processing will be run
     post_processing_workflow = ags.fields.Str(default = None, allow_none=True, description = "if not None, will submit postprocessing job here")
     job_dir = ags.fields.InputDir(default = "None",description= "Directory with job files for this cells run")
@@ -33,10 +33,12 @@ def main(args, **kwargs):
     sqlite_runs_table_id = args['sqlite_runs_table_id']
     autotrace_tracking_database = args['autotrace_tracking_database']
 
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='pipeline',
-                  state='finish')
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None):
+
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='pipeline',
+                    state='finish')
     
     # If swc post processing workflow was given as an input, submit a job from here. We dont want
     # this job tracked in our SLURM DAG because post processing takes a while to run as seen in time request

--- a/patchseq_autotrace/commands/post_process_segmentation.py
+++ b/patchseq_autotrace/commands/post_process_segmentation.py
@@ -7,10 +7,11 @@ from patchseq_autotrace.database_tools import status_update
 class IO_Schema(ags.ArgSchema):
     specimen_dir = ags.fields.InputDir(description='Input Subject Directory')
     model_name = ags.fields.Str(description='model name to use ')
-    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file")
+    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file",default=None,allow_none=True)
     autotrace_tracking_database = ags.fields.InputFile(
         description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
-                    "patchseq_autotrace.database_tools prior to running this script")
+                    "patchseq_autotrace.database_tools prior to running this script",default=None,allow_none=True)
+
 
 def main(args, **kwargs):
 
@@ -18,19 +19,20 @@ def main(args, **kwargs):
     model_name = args['model_name']
     sqlite_runs_table_id = args['sqlite_runs_table_id']
     autotrace_tracking_database = args['autotrace_tracking_database']
-
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='postprocessing',
-                  state='start')
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None):
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='postprocessing',
+                    state='start')
 
     segmentation_dir = os.path.join(specimen_dir, "Segmentation")
     postprocess(specimen_dir, segmentation_dir=segmentation_dir, model_name=model_name)
 
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='postprocessing',
-                  state='finish')
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None):
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='postprocessing',
+                    state='finish')
 
 
 def console_script():

--- a/patchseq_autotrace/commands/pre_process_directory.py
+++ b/patchseq_autotrace/commands/pre_process_directory.py
@@ -28,7 +28,7 @@ def main(args, **kwargs):
     autotrace_tracking_database = args['autotrace_tracking_database']
     generate_raw_mip = args['generate_raw_mip']
     use_multiprocessing = args['use_multiprocessing']
-
+    print("Using multiprocessing for specimen {}: {}".format(specimen_dir,use_multiprocessing))
     status_update(database_path=autotrace_tracking_database,
                   runs_unique_id=sqlite_runs_table_id,
                   process_name='preprocessing',

--- a/patchseq_autotrace/commands/pre_process_directory.py
+++ b/patchseq_autotrace/commands/pre_process_directory.py
@@ -12,14 +12,14 @@ from patchseq_autotrace.database_tools import status_update
 class IO_Schema(ags.ArgSchema):
     specimen_dir = ags.fields.InputDir(description='Input Subject Directory, expecting Single_Tif_Images subdir exists')
     chunk_size = ags.fields.Int(default=32, description="Num Tif Images to Stack into Chunks")
-    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file")
+    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file", default=None, allow_none=True)
     autotrace_tracking_database = ags.fields.InputFile(
         description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
-                    "patchseq_autotrace.database_tools prior to running this script")
+                    "patchseq_autotrace.database_tools prior to running this script", default=None, allow_none=True)
     generate_raw_mip = ags.fields.Bool(description="bool indicating whether to generate max intensity projection for raw images",
                                    default=False)
     use_multiprocessing = ags.fields.Bool(description='whether to use multiprocessing or not')
-
+    invert_images = ags.fields.Bool(description="whether or not to invert images.Signal should be bright and background should be dark",default=True)
 
 def main(args, **kwargs):
     specimen_dir = args['specimen_dir']
@@ -28,14 +28,17 @@ def main(args, **kwargs):
     autotrace_tracking_database = args['autotrace_tracking_database']
     generate_raw_mip = args['generate_raw_mip']
     use_multiprocessing = args['use_multiprocessing']
+    invert_images = args['invert_images']
+
     print("Using multiprocessing for specimen {}: {}".format(specimen_dir,use_multiprocessing))
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='preprocessing',
-                  state='start')
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None ):
+
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='preprocessing',
+                    state='start')
 
     specimen_id = os.path.basename(os.path.abspath(specimen_dir))
-    print(specimen_id)
     # # Ensure image directory exists
     input_image_dir = os.path.join(specimen_dir, "Single_Tif_Images")
     if not os.path.exists(input_image_dir):
@@ -46,13 +49,15 @@ def main(args, **kwargs):
 
     # Find crop dimensions and crop the images
     x1, y1, x2, y2 = crop_dimensions(input_image_dir)
-    crop_and_invert_directory_multiproc(input_image_dir, x1, x2, y1, y2, chunk_size, parallel=use_multiprocessing)
+    crop_and_invert_directory_multiproc(input_image_dir, x1, x2, y1, y2, chunk_size, parallel=use_multiprocessing, invert_images = invert_images)
 
     # Create bounding box file
     bb_file = os.path.join(specimen_dir, 'bbox_{}.json'.format(specimen_id))
     bound_box = solve_for_bounding_box(input_image_dir, chunk_size)
+    n_tiff_files = len([i for i in os.listdir(input_image_dir) if '.tif' in i])
     bb_dict = {"specimen_id": specimen_id,
-               "bounding_box": bound_box}
+               "bounding_box": bound_box,
+               "num_tiff_files":n_tiff_files}
     with open(bb_file, "w") as f:
         json.dump(bb_dict, f)
 
@@ -69,13 +74,14 @@ def main(args, **kwargs):
     convert_stack_to_3dchunks(chunk_size, input_image_dir, chunk_dir)
 
     # remove single tif directory since it is no longer needed at this point
-    shutil.rmtree(input_image_dir)
+    # shutil.rmtree(input_image_dir)
     
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None ):
     
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='preprocessing',
-                  state='finish')
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='preprocessing',
+                    state='finish')
 
 def console_script():
     this_module = ags.ArgSchemaParser(schema_type=IO_Schema)

--- a/patchseq_autotrace/commands/skeleton_stack_to_swc.py
+++ b/patchseq_autotrace/commands/skeleton_stack_to_swc.py
@@ -6,10 +6,10 @@ from patchseq_autotrace.database_tools import status_update
 class IO_Schema(ags.ArgSchema):
     specimen_dir = ags.fields.InputDir(description='Input Subject Directory')
     model_name = ags.fields.Str(description='model name to use ')
-    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file")
+    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file",allow_none=True,default=None)
     autotrace_tracking_database = ags.fields.InputFile(
         description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
-                    "patchseq_autotrace.database_tools prior to running this script")
+                    "patchseq_autotrace.database_tools prior to running this script",allow_none=True,default=None)
 
 
 def main(args, **kwargs):
@@ -17,18 +17,21 @@ def main(args, **kwargs):
     model_name = args['model_name']
     sqlite_runs_table_id = args['sqlite_runs_table_id']
     autotrace_tracking_database = args['autotrace_tracking_database']
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None ):
 
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='stack2swc',
-                  state='start')
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='stack2swc',
+                    state='start')
 
     skeleton_to_swc(specimen_dir=specimen_dir, model_and_version=model_name)
 
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='stack2swc',
-                  state='finish')
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None ):
+        
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='stack2swc',
+                    state='finish')
 
 def console_script():
     module = ags.ArgSchemaParser(schema_type=IO_Schema)

--- a/patchseq_autotrace/commands/validate_directory.py
+++ b/patchseq_autotrace/commands/validate_directory.py
@@ -14,10 +14,11 @@ class IO_Schema(ags.ArgSchema):
     chunk_size = ags.fields.Int(default=32, description="Num Tif Images to Stack into Chunks")
     model_name = ags.fields.Str(description='path to model checkpoint')
     gpu_device = ags.fields.Int(default=0)
-    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file")
+    sqlite_runs_table_id = ags.fields.Int(description="unique ID key for runs table in the sqlite .db file",default=None,allow_none=True)
     autotrace_tracking_database = ags.fields.InputFile(
         description="sqlite tracking .db file. This should exist and have specimen_runs table setup as seen in "
-                    "patchseq_autotrace.database_tools prior to running this script")
+                    "patchseq_autotrace.database_tools prior to running this script",
+                    default=None,allow_none=True)
 
 def main(args, **kwargs):
     specimen_dir = args['specimen_dir']
@@ -27,10 +28,12 @@ def main(args, **kwargs):
     sqlite_runs_table_id = args['sqlite_runs_table_id']
     autotrace_tracking_database = args['autotrace_tracking_database']
 
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='segmentation',
-                  state='start')
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None ):
+            
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='segmentation',
+                    state='start')
 
     specimen_id = os.path.basename(os.path.abspath(specimen_dir))
     chunk_dir = os.path.join(specimen_dir, 'Chunks_of_{}'.format(chunk_size))
@@ -41,11 +44,12 @@ def main(args, **kwargs):
     # bb = df.bound_boxing.values
 
     validate(model_name, specimen_dir, chunk_dir, bb, gpu_device, chunk_size)
-
-    status_update(database_path=autotrace_tracking_database,
-                  runs_unique_id=sqlite_runs_table_id,
-                  process_name='segmentation',
-                  state='finish')
+    
+    if (sqlite_runs_table_id is not None) and (autotrace_tracking_database is not None ):
+        status_update(database_path=autotrace_tracking_database,
+                    runs_unique_id=sqlite_runs_table_id,
+                    process_name='segmentation',
+                    state='finish')
 
 def console_script():
     module = ags.ArgSchemaParser(schema_type=IO_Schema)

--- a/patchseq_autotrace/processes/postprocess.py
+++ b/patchseq_autotrace/processes/postprocess.py
@@ -49,6 +49,8 @@ def postprocess(specimen_dir, segmentation_dir, model_name, threshold=0.3, size_
 
         # find x,y,z and intensity values for non zero coordinates
         csv_ofile = os.path.join(specimen_dir, "Segmentation_{}.csv".format(chan))
+        if os.path.exists(csv_ofile):
+            os.remove(csv_ofile)
         cgx, cgy, cgz = extract_non_zero_coords(tif_directory=channel_dir, thresh=thresh, max_list_size=500000,
                                                 output_csv=csv_ofile)
 

--- a/patchseq_autotrace/processes/pre_process.py
+++ b/patchseq_autotrace/processes/pre_process.py
@@ -71,7 +71,7 @@ def crop_dimensions(input_tif_dir, base=64):
     return x1, y1, x2, y2
 
 
-def _crop_and_invert(infile, ofile, x1, x2, y1, y2):
+def _crop_and_invert(infile, ofile, x1, x2, y1, y2, invert_bool):
     """
     crop inpuyt file given inices and invert the greyscale color vals
     :param infile:
@@ -84,20 +84,25 @@ def _crop_and_invert(infile, ofile, x1, x2, y1, y2):
     """
     img = cv2.imread(infile, cv2.IMREAD_UNCHANGED)
     cropped_img = img[y1:y2, x1:x2]
-    cropped_img_inverted = 255 - cropped_img
-    cv2.imwrite(ofile, cropped_img_inverted)
+    if invert_bool:
+        final_img = 255 - cropped_img
+    else:
+        final_img = cropped_img
+    cv2.imwrite(ofile, final_img)
 
 
-def crop_and_invert_directory_multiproc(input_tif_dir, x1, x2, y1, y2, chunk_size, parallel):
+def crop_and_invert_directory_multiproc(input_tif_dir, x1, x2, y1, y2, chunk_size, parallel, invert_images=True):
+    print("Cropping and inverting (?invert_bool={}?)\n{}".format(invert_images,input_tif_dir))
+    
     parallel_func_inputs = []
     tif_files = get_tifs(input_tif_dir)
     for fn in tif_files:
         infile = os.path.join(input_tif_dir, fn)
         ofile = infile
         if parallel:
-            parallel_func_inputs.append((infile, ofile, x1, x2, y1, y2))
+            parallel_func_inputs.append((infile, ofile, x1, x2, y1, y2, invert_images))
         else:
-            _crop_and_invert(infile, ofile, x1, x2, y1, y2)
+            _crop_and_invert(infile, ofile, x1, x2, y1, y2, invert_images)
             
     if parallel:
         p = Pool(processes=chunk_size)

--- a/patchseq_autotrace/processes/validation.py
+++ b/patchseq_autotrace/processes/validation.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import json
 import tifffile as tif
 from neuroseg.nets.RSUNetMulti import RSUNetMulti
 from neuroseg.core.predictor_multilabel import Predictor
@@ -18,6 +19,13 @@ def validate(model_name_version, specimen_dir, chunk_dir, bb, gpu, chunk_size):
     
     specimen_id = os.path.basename(os.path.abspath(specimen_dir))
     _, number_of_individual_tiffs = get_jp2_slice_size_and_stack_length(specimen_id)
+    if number_of_individual_tiffs is None:
+        bb_file = os.path.join(specimen_dir, 'bbox_{}.json'.format(specimen_id))
+        
+        with open(bb_file, "r") as f:
+            bound_box_dict = json.load(f)
+        
+        number_of_individual_tiffs = bound_box_dict['num_tiff_files']
         
     net = RSUNetMulti()
     data_text = MODEL_NAME_PATHS[model_name_version]

--- a/patchseq_autotrace/utils.py
+++ b/patchseq_autotrace/utils.py
@@ -33,7 +33,7 @@ def query(query, user, host, database,
     conn, cursor = _connect(user, host, database, password, port)
 
     # Guard against non-ascii characters in query
-    query = ''.join([i if ord(i) < 128 else ' ' for i in query])
+    query = ''.join([i if ord(i) < 128 else ' ' for i in query]) 
 
     try:
         results = _select(cursor, query)
@@ -61,9 +61,13 @@ def get_jp2_slice_size_and_stack_length(specimen_id):
     
     """
     arg_dicts = query_for_image_paths(specimen_id)
-    single_file_size = os.path.getsize("/"+arg_dicts[0]['input_jp2'])
-    return single_file_size, len(arg_dicts)
-
+    if len(arg_dicts)>1:
+        single_file_size = os.path.getsize("/"+arg_dicts[0]['input_jp2'])
+        return single_file_size, len(arg_dicts)
+    else:
+        print("WARNING: No images found for specimen {}".format(specimen_id))
+        return None,None
+    
 def query_for_image_paths(specimen_id, query_engine=None):
     """Get an SWC file path for a specimen ID using the specified query engine"""
     if query_engine is None:
@@ -102,10 +106,13 @@ def estimate_stack_size(specimen_id):
     intercept=-13418532.504622981
 
     jp2_slice_size, num_slices = get_jp2_slice_size_and_stack_length(specimen_id)
-    est_tiff_slice_size = (jp2_slice_size*slope)+intercept
-    est_tiff_stack_size = est_tiff_slice_size*num_slices
-    est_tiff_size_gb = est_tiff_stack_size/(1024**3)
-    return est_tiff_size_gb
+    if jp2_slice_size is not None:
+        est_tiff_slice_size = (jp2_slice_size*slope)+intercept
+        est_tiff_stack_size = est_tiff_slice_size*num_slices
+        est_tiff_size_gb = est_tiff_stack_size/(1024**3)
+        return est_tiff_size_gb
+    else:
+        return 0
 
 
 

--- a/patchseq_autotrace/utils.py
+++ b/patchseq_autotrace/utils.py
@@ -154,7 +154,12 @@ def get_63x_soma_coords(specimen_id, query_engine=None):
     select max(id) as image_series_id from image_series
     where specimen_id = {}
     group by specimen_id""".format(int(specimen_id))
-    imser_id_63x = query_engine(query)[0]['image_series_id']
+    imser_id_63x = query_engine(query)
+    if imser_id_63x == []:
+        return None,None
+    
+    else:
+        imser_id_63x = imser_id_63x[0]['image_series_id']
 
     sql_query = """
     select distinct 


### PR DESCRIPTION
- enable immediate swc post process kickoff once cell finishes raw autotrace generation
- drop pipeline database file and database ID requirement, now these are optional input args
- invert_image is now an option for end users for pre processing, if they start with light/dark scale images